### PR TITLE
widen the interface

### DIFF
--- a/rinnaicontrolr/base.py
+++ b/rinnaicontrolr/base.py
@@ -62,12 +62,30 @@ class RinnaiWaterHeater(object):
         # that would also require other changes to this file.
         self._get_initial_token()
 
-    def getDevices(self):
-        """Returns a list of devices, one for each water heater associated
-        with self.username."""
+    def _set_shadow(self, dev, attribute, value):
+        """Use the (unauthenticated) shadow API to set attribute to value
+        on device dev."""
+        data = {
+            'user': dev['user_uuid'],
+            'thing': dev['thing_name'],
+            'attribute': attribute,
+            'value': value
+        }
+        headers = {
+            'User-Agent': 'okhttp/3.12.1'
+        }
+        r = requests.post(SHADOW_ENDPOINT, data=data, headers=headers)
+        r.raise_for_status()
+        return r
 
-        # we should call validate_token() here to ensure we have an access token.
-        # except Rinnai's API is not authenticated, so we don't need an access token.
+    def get_devices(self):
+        """Returns a list of devices, one for each water heater associated
+        with self.username. A device is just a dictionary of data for that
+        device. If you want to refresh the data for the device,
+        call this method again."""
+
+        # We should call validate_token() here to ensure we have an access token.
+        # Except Rinnai's API is not authenticated, so we don't need an access token.
         # self.validate_token()
 
         payload = GET_DEVICES_PAYLOAD % (self.username)
@@ -84,41 +102,28 @@ class RinnaiWaterHeater(object):
             for k,v in items['devices'].items():
                 return v
 
+    def start_recirculation(self, dev, duration: int):
+        """Start recirculation on the specified device. dev is one of the devices
+        returned by get_devices()."""
+
+        self._set_shadow(dev, 'set_priority_status', 'true')
+        self._set_shadow(dev, 'recirculation_duration', str(duration))
+        return self._set_shadow(dev, 'set_recirculation_enabled', 'true')
+
+    def is_recirculating(self, dev):
+        return dev['shadow']['recirculation_enabled']
+
+    def set_temperature_setpoint(self, dev, temp: int):
+        self._set_shadow(dev, 'set_priority_status', 'true')
+        return self._set_shadow(dev, 'set_domestic_temperature', str(temp))
+
+    def get_temperature_setpoint(self, dev):
+        return dev['info']['domestic_temperature']
+
+    def is_heating(self, dev):
+        return dev['info']['domestic_combustion'] == 'true'
+
     @property
     def is_connected(self):
         """Connection status of client with Rinnai Cloud service"""
         return time.time() < self.token.get('expires_at', 0)
-
-    def start_recirculation(self, dev, duration: int):
-        """Start recirculation on the specified device. dev is one of the devices
-        returned by get_devices()."""
-        thing_name = dev['thing_name']
-        user_uuid = dev['user_uuid']
-        headers = {
-          'User-Agent': 'okhttp/3.12.1',
-          'Content-Type': 'application/x-www-form-urlencoded'
-        }
-        payload = "user=%s&thing=%s&attribute=set_priority_status&value=true" % (user_uuid, thing_name)
-        r = requests.post(
-            SHADOW_ENDPOINT,
-            data=payload,
-            headers=headers
-        )
-        r.raise_for_status()
-
-        payload = "user=%s&thing=%s&attribute=recirculation_duration&value=%s" % (user_uuid, thing_name, duration)
-        r = requests.post(
-            SHADOW_ENDPOINT,
-            data=payload,
-            headers=headers
-        )
-        r.raise_for_status()
-
-        payload = "user=%s&thing=%s&attribute=set_recirculation_enabled&value=true" % (user_uuid, thing_name)
-        r = requests.post(
-            SHADOW_ENDPOINT,
-            data=payload,
-            headers=headers
-        )
-        r.raise_for_status()
-        return r

--- a/rinnaicontrolr/const.py
+++ b/rinnaicontrolr/const.py
@@ -4,6 +4,9 @@ POOL_ID = 'cognitor-idp.us-east-1.amazonaws.com/us-east-1_OcwpRQbMM'
 CLIENT_ID = '5ghq3i6k4p9s7dfu34ckmec91'
 POOL_REGION = 'us-east-1'
 
+GRAPHQL_ENDPOINT = 'https://s34ox7kri5dsvdr43bfgp6qh6i.appsync-api.us-east-1.amazonaws.com/graphql'
+SHADOW_ENDPOINT = 'https://d1coipyopavzuf.cloudfront.net/api/device_shadow/input'
+
 GET_DEVICES_PAYLOAD = ("{\r\n    \"query\": \"query GetUserByEmail($email: String, $sortDirection: ModelSortDirection, $filter: ModelRinnaiUserFilterInput, $limit: Int, $nextToken: String) "
                    "{\\n  getUserByEmail(email: $email, sortDirection: $sortDirection, filter: $filter, limit: $limit, nextToken: $nextToken) {\\n    items {devices {\\n        "
                    "items {\\n          id\\n          thing_name\\n          device_name\\n          dealer_uuid\\n          "


### PR DESCRIPTION
When merged, this pull request adds additional interface methods for setting and retrieving the temperature setpoint, and retrieving recirculation and heating state.

It also changes getDevices() to the more-pythonic get_devices(), and it makes start_recirculation() take a device (that is, one of the list items returned by get_devices()) instead of other values that the caller previously had to extract from the device dictionary.

Finally, it makes clear that the API isn't authenticated -- it doesn't call validate_token() because there's no reason to.

Also general cleanups/refactoring.